### PR TITLE
Add limits to all 3 motors and set them and velocities; fix 92-...py

### DIFF
--- a/startup/00-startup.py
+++ b/startup/00-startup.py
@@ -2,7 +2,7 @@ from nslsii import configure_base
 from IPython import get_ipython
 
 configure_base(get_ipython().user_ns, 'local')
-
+bec.disable_plots()
 
 # Optional: set any metadata that rarely changes.
 RE.md['beamline_id'] = 'TES-sim'

--- a/startup/20-motors.py
+++ b/startup/20-motors.py
@@ -1,10 +1,22 @@
 from ophyd import (EpicsSignal, EpicsMotor, Device, Component as Cpt)
 
 
+class EpicsMotorWithLimits(EpicsMotor):
+    hlm = Cpt(EpicsSignal, '.HLM', kind='config')
+    llm = Cpt(EpicsSignal, '.LLM', kind='config')
+
+
 class SampleStage(Device):
-    x = Cpt(EpicsMotor, '1')
-    y = Cpt(EpicsMotor, '2')
-    z = Cpt(EpicsMotor, '3')
+    # Motor 1 has a higher minimum velocity (2), and a lower upper bound (180),
+    # that's why we'll be using motors 2-4 to have a more configurable env.
+    x = Cpt(EpicsMotorWithLimits, '2')
+    y = Cpt(EpicsMotorWithLimits, '3')
+    z = Cpt(EpicsMotorWithLimits, '4')
 
 
 sample_stage = SampleStage('IOC:m', name='sample_stage')
+
+for cpt in sample_stage.component_names:
+    getattr(sample_stage, cpt).llm.put(-1000)
+    getattr(sample_stage, cpt).hlm.put(1000)
+    getattr(sample_stage, cpt).velocity.put(5.0)

--- a/startup/92-optimization.py
+++ b/startup/92-optimization.py
@@ -91,7 +91,7 @@ class HardwareFlyer(BlueskyFlyer):
         #
         # ZeroDivisionError: float division by zero
         for motor_name, motor_obj in self.motors.items():
-            motor_obj.velocity.put(self.velocities[motor_name] / 20)
+            motor_obj.velocity.put(self.velocities[motor_name])
 
         for motor_name, motor_obj in self.motors.items():
             if motor_name == slowest_motor:
@@ -176,17 +176,6 @@ class HardwareFlyer(BlueskyFlyer):
 
 params_to_change = []
 
-from ophyd import (EpicsSignal, EpicsMotor, Device, Component as Cpt)
-
-
-class SampleStage(Device):
-    x = Cpt(EpicsMotor, '1')
-    y = Cpt(EpicsMotor, '2')
-    z = Cpt(EpicsMotor, '3')
-
-
-sample_stage = SampleStage('IOC:m', name='sample_stage')
-
 motors = {sample_stage.x.name: sample_stage.x,
           sample_stage.y.name: sample_stage.y,
           sample_stage.z.name: sample_stage.z,}
@@ -231,16 +220,16 @@ Out[11]: 22.22
 # params_to_change.append({sample_stage.x.name: 71,
 #                          sample_stage.y.name: 39,
 #                          sample_stage.z.name: 22.9})
-params_to_change.append({sample_stage.x.name: 20,
-                         sample_stage.y.name: 10,
-                         sample_stage.z.name: 35})
+params_to_change.append({sample_stage.x.name: 100,
+                         sample_stage.y.name: 80,
+                         sample_stage.z.name: 0})
 
 params_to_change.append({sample_stage.x.name: 40,
-                         sample_stage.y.name: 40,
+                         sample_stage.y.name: 30,
                          sample_stage.z.name: 50})
 
 params_to_change.append({sample_stage.x.name: 60,
-                         sample_stage.y.name: 70,
+                         sample_stage.y.name: 100,
                          sample_stage.z.name: 10})
 
 # update function - change params
@@ -350,7 +339,7 @@ def optimize():
                 dists.append(abs(param[motor_name] - params_to_change[i - 1][motor_name]))
         velocities = calc_velocity(motors.keys(), dists, velocity_limits, max_velocity=5)
         if velocities is None:
-            velocities = [.5, .5, .5]
+            velocities = [5.0, 5.0, 5.0]
         for motor_name, vel, dist in zip(motors, velocities, dists):
             velocities_dict[motor_name] = vel
             distances_dict[motor_name] = dist
@@ -404,12 +393,9 @@ def optimize():
                            velocities=vel,
                            time_to_travel=time_,
                            detector=None, motors=motors)
-        # yield from bp.fly([hf])
+        yield from bp.fly([hf])
 
         hf_flyers.append(hf)
-
-
-optimize()
 
 
 def move_back():


### PR DESCRIPTION
This PR adds limit components to the EpicsMotor, so they can be set from ophyd.
Also, it sets the initial limits and the velocities.

I fixes the 92-optimization.py so that the scan can run successfully.

The IPython startup files from this repo should be run with the following simulated motor IOC:
```
docker run -it --rm --name motorsim --network=host mikehart/motorsim
```

**Observation**: with the simulated motor from the docker container mentioned above does not behave properly if the velocities are set below 1 (e.g., to 0.5). Reliable results were observed with the speeds=5 mm/s. Needs more testing to find the lowest velocities.